### PR TITLE
Implement customers page with user table and edit modal

### DIFF
--- a/src/crm/components/EditUserModal.tsx
+++ b/src/crm/components/EditUserModal.tsx
@@ -1,0 +1,252 @@
+import * as React from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import { User, usersApi } from "../../services/usersApi";
+
+interface EditUserModalProps {
+  open: boolean;
+  user: User | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function EditUserModal({
+  open,
+  user,
+  onClose,
+  onSuccess,
+}: EditUserModalProps) {
+  const [firstName, setFirstName] = React.useState<string>("");
+  const [lastName, setLastName] = React.useState<string>("");
+  const [title, setTitle] = React.useState<string>("");
+  const [email, setEmail] = React.useState<string>("");
+  const [city, setCity] = React.useState<string>("");
+  const [country, setCountry] = React.useState<string>("");
+  const [phone, setPhone] = React.useState<string>("");
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState<boolean>(false);
+
+  // Populate form when user changes
+  React.useEffect(() => {
+    if (user) {
+      setFirstName(user.name.first || "");
+      setLastName(user.name.last || "");
+      setTitle(user.name.title || "");
+      setEmail(user.email || "");
+      setCity(user.location.city || "");
+      setCountry(user.location.country || "");
+      setPhone(user.phone || "");
+      setError(null);
+      setSuccess(false);
+    }
+  }, [user]);
+
+  const handleSave = async () => {
+    if (!user) return;
+
+    // Validation
+    if (!firstName.trim() || !lastName.trim()) {
+      setError("First name and last name are required");
+      return;
+    }
+
+    if (!email.trim()) {
+      setError("Email is required");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      await usersApi.updateUser(user.login.uuid, {
+        name: {
+          first: firstName,
+          last: lastName,
+          title: title,
+        },
+        email: email,
+        location: {
+          city: city,
+          country: country,
+        },
+        phone: phone,
+      });
+
+      setSuccess(true);
+      
+      // Close modal and refresh data after a short delay
+      setTimeout(() => {
+        onSuccess();
+        onClose();
+      }, 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update user");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog 
+      open={open} 
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "8px",
+        },
+      }}
+    >
+      <DialogTitle 
+        sx={{ 
+          fontWeight: 600,
+          fontSize: "20px",
+          pb: 2,
+        }}
+      >
+        Edit User
+      </DialogTitle>
+      
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        
+        {success && (
+          <Alert severity="success" sx={{ mb: 2 }}>
+            User updated successfully!
+          </Alert>
+        )}
+
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {/* Title */}
+          <TextField
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            fullWidth
+            size="small"
+            sx={{
+              "& input": {
+                fontFamily: "Helvetica, Inter, -apple-system, Roboto, sans-serif",
+              },
+            }}
+          />
+
+          {/* First Name - Using Helvetica font as per PRD */}
+          <TextField
+            label="First Name"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            required
+            fullWidth
+            size="small"
+            sx={{
+              "& input": {
+                fontFamily: "Helvetica, Inter, -apple-system, Roboto, sans-serif",
+                minWidth: "300px",
+              },
+            }}
+          />
+
+          {/* Last Name - Using Helvetica font as per PRD */}
+          <TextField
+            label="Last Name"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            required
+            fullWidth
+            size="small"
+            sx={{
+              "& input": {
+                fontFamily: "Helvetica, Inter, -apple-system, Roboto, sans-serif",
+                minWidth: "300px",
+              },
+            }}
+          />
+
+          {/* Email */}
+          <TextField
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            fullWidth
+            size="small"
+          />
+
+          {/* City */}
+          <TextField
+            label="City"
+            value={city}
+            onChange={(e) => setCity(e.target.value)}
+            fullWidth
+            size="small"
+          />
+
+          {/* Country */}
+          <TextField
+            label="Country"
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            fullWidth
+            size="small"
+          />
+
+          {/* Phone */}
+          <TextField
+            label="Phone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            fullWidth
+            size="small"
+          />
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button 
+          onClick={handleClose} 
+          disabled={loading}
+          sx={{ textTransform: "none" }}
+        >
+          Cancel
+        </Button>
+        <Button 
+          onClick={handleSave} 
+          variant="contained"
+          disabled={loading}
+          sx={{
+            textTransform: "none",
+            backgroundColor: "#05070A",
+            "&:hover": {
+              backgroundColor: "#0B0E14",
+            },
+          }}
+        >
+          {loading ? <CircularProgress size={20} /> : "Save"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/crm/components/UsersTable.tsx
+++ b/src/crm/components/UsersTable.tsx
@@ -1,0 +1,388 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import CircularProgress from "@mui/material/CircularProgress";
+import Alert from "@mui/material/Alert";
+import EditIcon from "@mui/icons-material/Edit";
+import { usersApi, User } from "../../services/usersApi";
+
+interface UsersTableProps {
+  onEditUser: (user: User) => void;
+}
+
+export default function UsersTable({ onEditUser }: UsersTableProps) {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = React.useState<string>("");
+  const [searchQuery, setSearchQuery] = React.useState<string>("");
+  const [currentPage, setCurrentPage] = React.useState<number>(1);
+  const [totalUsers, setTotalUsers] = React.useState<number>(0);
+  const [hasMore, setHasMore] = React.useState<boolean>(true);
+
+  const perPage = 20;
+
+  const fetchUsers = React.useCallback(async (page: number, search: string, append: boolean = false) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await usersApi.getUsers({
+        page,
+        perPage,
+        search: search || undefined,
+      });
+
+      if (append) {
+        setUsers(prev => [...prev, ...response.data]);
+      } else {
+        setUsers(response.data);
+      }
+
+      setTotalUsers(response.total);
+      setHasMore(users.length + response.data.length < response.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch users");
+    } finally {
+      setLoading(false);
+    }
+  }, [users.length]);
+
+  React.useEffect(() => {
+    fetchUsers(1, searchQuery);
+  }, [searchQuery]);
+
+  const handleSearch = () => {
+    setCurrentPage(1);
+    setSearchQuery(searchTerm);
+  };
+
+  const handleSearchKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleSearch();
+    }
+  };
+
+  const handleLoadMore = () => {
+    const nextPage = currentPage + 1;
+    setCurrentPage(nextPage);
+    fetchUsers(nextPage, searchQuery, true);
+  };
+
+  const getFullName = (user: User): string => {
+    return `${user.name.first} ${user.name.last}`;
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* Title */}
+      <Typography 
+        variant="h4" 
+        component="h1" 
+        sx={{ 
+          mb: 1,
+          fontWeight: 600,
+          fontSize: "24px",
+          lineHeight: "36px",
+        }}
+      >
+        Customers
+      </Typography>
+
+      <Typography 
+        variant="h6" 
+        component="h2" 
+        sx={{ 
+          mb: 2,
+          fontWeight: 600,
+          fontSize: "20px",
+          lineHeight: "26.68px",
+        }}
+      >
+        Users
+      </Typography>
+
+      {/* Search */}
+      <Box 
+        sx={{ 
+          display: "flex", 
+          gap: 2, 
+          mb: 3,
+          alignItems: "center",
+        }}
+      >
+        <TextField
+          placeholder="Search users by name, email, or city"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          onKeyPress={handleSearchKeyPress}
+          size="small"
+          sx={{
+            width: { xs: "100%", sm: "363px" },
+            "& .MuiOutlinedInput-root": {
+              borderRadius: "8px",
+              backgroundColor: "#FCFCFC",
+              "& fieldset": {
+                borderColor: "rgba(194, 201, 214, 0.40)",
+              },
+            },
+            "& input": {
+              fontSize: "16px",
+              color: "#999",
+            },
+          }}
+        />
+        <Button
+          variant="contained"
+          onClick={handleSearch}
+          sx={{
+            borderRadius: "8px",
+            backgroundColor: "#05070A",
+            color: "#FFF",
+            px: 3,
+            py: 1,
+            fontSize: "20px",
+            fontWeight: 500,
+            lineHeight: "24.5px",
+            textTransform: "none",
+            boxShadow: "0 1px 0 #47536B, 0 -1px 0 #000",
+            "&:hover": {
+              backgroundColor: "#0B0E14",
+            },
+          }}
+        >
+          Search
+        </Button>
+      </Box>
+
+      {/* Error Message */}
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      )}
+
+      {/* Table */}
+      <TableContainer 
+        sx={{ 
+          backgroundColor: "#F5F6FA",
+          borderRadius: "8px",
+          maxHeight: "calc(100vh - 300px)",
+          overflow: "auto",
+        }}
+      >
+        <Table 
+          stickyHeader 
+          sx={{ 
+            minWidth: 650,
+            "& .MuiTableCell-root": {
+              borderBottom: "0.5px solid #0B0E14",
+            },
+          }}
+        >
+          <TableHead>
+            <TableRow sx={{ backgroundColor: "#FCFCFC" }}>
+              <TableCell 
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "215px",
+                }}
+              >
+                Name
+              </TableCell>
+              <TableCell 
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "346px",
+                }}
+              >
+                Email
+              </TableCell>
+              <TableCell 
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "250px",
+                }}
+              >
+                City
+              </TableCell>
+              <TableCell 
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "163px",
+                }}
+              >
+                Country
+              </TableCell>
+              <TableCell 
+                align="right"
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "77px",
+                }}
+              >
+                Age
+              </TableCell>
+              <TableCell 
+                align="center"
+                sx={{ 
+                  fontWeight: 500,
+                  fontSize: "16px",
+                  lineHeight: "24px",
+                  backgroundColor: "#FCFCFC",
+                  width: "107px",
+                }}
+              >
+                Actions
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading && currentPage === 1 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <CircularProgress />
+                </TableCell>
+              </TableRow>
+            ) : users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                  <Typography variant="body1" color="text.secondary">
+                    No users found
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => (
+                <TableRow 
+                  key={user.login.uuid}
+                  hover
+                  sx={{
+                    "&:hover": {
+                      backgroundColor: "rgba(0, 0, 0, 0.04)",
+                    },
+                  }}
+                >
+                  <TableCell 
+                    sx={{ 
+                      fontSize: "16px",
+                      lineHeight: "20.02px",
+                      fontFamily: "Helvetica, Inter, -apple-system, Roboto, sans-serif",
+                    }}
+                  >
+                    {getFullName(user)}
+                  </TableCell>
+                  <TableCell 
+                    sx={{ 
+                      fontSize: "16px",
+                      lineHeight: "20.02px",
+                    }}
+                  >
+                    {user.email}
+                  </TableCell>
+                  <TableCell 
+                    sx={{ 
+                      fontSize: "16px",
+                      lineHeight: "20.02px",
+                    }}
+                  >
+                    {user.location.city}
+                  </TableCell>
+                  <TableCell 
+                    sx={{ 
+                      fontSize: "16px",
+                      lineHeight: "20.02px",
+                    }}
+                  >
+                    {user.location.country}
+                  </TableCell>
+                  <TableCell 
+                    align="right"
+                    sx={{ 
+                      fontSize: "16px",
+                      lineHeight: "20.02px",
+                    }}
+                  >
+                    {user.dob.age}
+                  </TableCell>
+                  <TableCell align="center">
+                    <IconButton
+                      size="small"
+                      onClick={() => onEditUser(user)}
+                      sx={{
+                        borderRadius: "8px",
+                        border: "1px solid #DADEE7",
+                        backgroundColor: "rgba(245, 246, 250, 0.30)",
+                        width: "40px",
+                        height: "40px",
+                        "&:hover": {
+                          backgroundColor: "rgba(245, 246, 250, 0.50)",
+                        },
+                      }}
+                      aria-label="edit user"
+                    >
+                      <EditIcon sx={{ fontSize: "20px", color: "#0B0E14" }} />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Load More Button */}
+      {hasMore && users.length > 0 && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 3 }}>
+          <Button
+            variant="outlined"
+            onClick={handleLoadMore}
+            disabled={loading}
+            sx={{
+              borderRadius: "8px",
+              border: "1px solid #DADEE7",
+              backgroundColor: "rgba(245, 246, 250, 0.30)",
+              color: "#000",
+              px: 3,
+              py: 1,
+              fontSize: "16px",
+              fontWeight: 500,
+              lineHeight: "24.5px",
+              textTransform: "none",
+              "&:hover": {
+                backgroundColor: "rgba(245, 246, 250, 0.50)",
+                border: "1px solid #DADEE7",
+              },
+            }}
+          >
+            {loading ? <CircularProgress size={20} /> : "Load More"}
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/crm/components/UsersTable.tsx
+++ b/src/crm/components/UsersTable.tsx
@@ -43,23 +43,27 @@ export default function UsersTable({ onEditUser }: UsersTableProps) {
       });
 
       if (append) {
-        setUsers(prev => [...prev, ...response.data]);
+        setUsers(prev => {
+          const newUsers = [...prev, ...response.data];
+          setHasMore(newUsers.length < response.total);
+          return newUsers;
+        });
       } else {
         setUsers(response.data);
+        setHasMore(response.data.length < response.total);
       }
 
       setTotalUsers(response.total);
-      setHasMore(users.length + response.data.length < response.total);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch users");
     } finally {
       setLoading(false);
     }
-  }, [users.length]);
+  }, [perPage]);
 
   React.useEffect(() => {
     fetchUsers(1, searchQuery);
-  }, [searchQuery]);
+  }, [searchQuery, fetchUsers]);
 
   const handleSearch = () => {
     setCurrentPage(1);

--- a/src/crm/pages/Customers.tsx
+++ b/src/crm/pages/Customers.tsx
@@ -1,17 +1,39 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
+import UsersTable from "../components/UsersTable";
+import EditUserModal from "../components/EditUserModal";
+import { User } from "../../services/usersApi";
 
 export default function Customers() {
+  const [selectedUser, setSelectedUser] = React.useState<User | null>(null);
+  const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
+  const [refreshKey, setRefreshKey] = React.useState<number>(0);
+
+  const handleEditUser = (user: User) => {
+    setSelectedUser(user);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedUser(null);
+  };
+
+  const handleUpdateSuccess = () => {
+    // Trigger a refresh of the users table
+    setRefreshKey(prev => prev + 1);
+  };
+
   return (
-    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" } }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 4 }}>
-        Customers Page
-      </Typography>
-      <Typography paragraph>
-        This is the customers management page where you can view and manage your
-        customer data.
-      </Typography>
+    <Box sx={{ width: "100%", maxWidth: { sm: "100%", md: "1700px" }, p: 3 }}>
+      <UsersTable key={refreshKey} onEditUser={handleEditUser} />
+      
+      <EditUserModal
+        open={isModalOpen}
+        user={selectedUser}
+        onClose={handleCloseModal}
+        onSuccess={handleUpdateSuccess}
+      />
     </Box>
   );
 }

--- a/src/services/usersApi.ts
+++ b/src/services/usersApi.ts
@@ -1,0 +1,189 @@
+// Users API Service
+// Base URL: https://user-api.builder-io.workers.dev/api
+
+const BASE_URL = "https://user-api.builder-io.workers.dev/api";
+
+export interface UserLocation {
+  street: {
+    number: number;
+    name: string;
+  };
+  city: string;
+  state: string;
+  country: string;
+  postcode: string;
+  coordinates?: {
+    latitude: number;
+    longitude: number;
+  };
+  timezone?: {
+    offset: string;
+    description: string;
+  };
+}
+
+export interface UserName {
+  title: string;
+  first: string;
+  last: string;
+}
+
+export interface UserLogin {
+  uuid: string;
+  username: string;
+  password: string;
+}
+
+export interface UserDob {
+  date: string;
+  age: number;
+}
+
+export interface UserRegistered {
+  date: string;
+  age: number;
+}
+
+export interface UserPicture {
+  large: string;
+  medium: string;
+  thumbnail: string;
+}
+
+export interface User {
+  login: UserLogin;
+  name: UserName;
+  gender: string;
+  location: UserLocation;
+  email: string;
+  dob: UserDob;
+  registered: UserRegistered;
+  phone: string;
+  cell: string;
+  picture: UserPicture;
+  nat: string;
+}
+
+export interface UsersListResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  span: string;
+  effectivePage: number;
+  data: User[];
+}
+
+export interface GetUsersParams {
+  page?: number;
+  perPage?: number;
+  search?: string;
+  sortBy?: string;
+  span?: string;
+}
+
+export interface CreateUserData {
+  email: string;
+  login: {
+    username: string;
+    password?: string;
+  };
+  name: UserName;
+  gender?: string;
+  location?: Partial<UserLocation>;
+}
+
+export interface UpdateUserData {
+  name?: Partial<UserName>;
+  email?: string;
+  location?: Partial<UserLocation>;
+  gender?: string;
+  phone?: string;
+  cell?: string;
+}
+
+class UsersApiService {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = BASE_URL) {
+    this.baseUrl = baseUrl;
+  }
+
+  async getUsers(params: GetUsersParams = {}): Promise<UsersListResponse> {
+    const queryParams = new URLSearchParams();
+    
+    if (params.page) queryParams.append("page", params.page.toString());
+    if (params.perPage) queryParams.append("perPage", params.perPage.toString());
+    if (params.search) queryParams.append("search", params.search);
+    if (params.sortBy) queryParams.append("sortBy", params.sortBy);
+    if (params.span) queryParams.append("span", params.span);
+
+    const url = `${this.baseUrl}/users?${queryParams.toString()}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch users: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getUserById(id: string): Promise<User> {
+    const url = `${this.baseUrl}/users/${id}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch user: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async createUser(userData: CreateUserData): Promise<{ success: boolean; uuid: string; message: string }> {
+    const url = `${this.baseUrl}/users`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(userData),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to create user: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async updateUser(id: string, userData: UpdateUserData): Promise<{ success: boolean; message: string }> {
+    const url = `${this.baseUrl}/users/${id}`;
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(userData),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to update user: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async deleteUser(id: string): Promise<{ success: boolean; message: string }> {
+    const url = `${this.baseUrl}/users/${id}`;
+    const response = await fetch(url, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to delete user: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+}
+
+export const usersApi = new UsersApiService();


### PR DESCRIPTION
## Summary
This PR implements the full functionality for the Customers page, allowing users to view a list of customers and edit their details via a modal interface.

## Problem
The Customers page was previously a static placeholder and lacked the ability to interact with customer data or perform management actions.

## Solution
Implemented a comprehensive solution including a dedicated API service for fetching and updating user data, a responsive table component for display, and a form modal for editing user information.

## Key Changes
- **API Service**: Created `usersApi.ts` to handle CRUD operations with the backend.
- **UI Components**:
  - `UsersTable`: Displays user data with "Load More" pagination and search capabilities.
  - `EditUserModal`: Provides a form to update user details (Name, Email, Location, Phone) with validation.
- **Integration**: Updated the `Customers` page to manage state between the table and the edit modal.
- **Styling**: Applied specific font families (Helvetica/Inter) and responsive design principles using Material UI.

## Files Changed
- `src/crm/pages/Customers.tsx`: Integrated table and modal components.
- `src/crm/components/UsersTable.tsx`: New component for rendering the user list.
- `src/crm/components/EditUserModal.tsx`: New component for the user edit form.
- `src/services/usersApi.ts`: New service file for API definitions and methods.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/fc4f1fc2d2e14c0ebf9f55ec5176908f/vortex-field)

👀 [Preview Link](https://fc4f1fc2d2e14c0ebf9f55ec5176908f-vortex-field.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fc4f1fc2d2e14c0ebf9f55ec5176908f</projectId>-->
<!--<branchName>vortex-field</branchName>-->